### PR TITLE
Use Grunt API to write file

### DIFF
--- a/tasks/doxdox.js
+++ b/tasks/doxdox.js
@@ -64,7 +64,7 @@ module.exports = function (grunt) {
                 config.package
             ).then(function (content) {
 
-                fs.writeFileSync(output, content, 'utf8');
+                grunt.file.write(output, content, {encoding: 'utf8'});
 
                 done();
 


### PR DESCRIPTION
This way it guarantees that all the intermediate directories are created if not already existing.
